### PR TITLE
Release v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 3
 
 [[package]]
 name = "rgbds-obj"
-version = "0.1.1"
+version = "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rgbds-obj"
-version = "0.1.1" # Remember to sync html_root_url in `main.rs`
+version = "0.2.0" # Remember to sync html_root_url in `lib.rs`
 authors = ["ISSOtm <me@eldred.fr>"]
 edition = "2018"
 description = "A library for working with RGBDS object files."

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@
 //!
 //! [RGBDS]: https://rgbds.gbdev.io
 
-#![doc(html_root_url = "https://docs.rs/rgbds-obj/0.1.0")]
+#![doc(html_root_url = "https://docs.rs/rgbds-obj/0.2.0")]
 
 use std::convert::TryInto;
 use std::error::Error;


### PR DESCRIPTION
This updates `html_root_url` (which v0.1.1 forgot to do, lol).

After https://github.com/gbdev/rgbobj/pull/6 merges, rgbobj should be updated to use rgbds-obj v0.2.0, print the actual object version instead of hard-coded v9, and release rgbobj v0.3.0 (just in time for rgbds v0.8.0).