### PR TITLE
Release 0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rgbds-obj"
-version = "0.2.1" # Remember to sync html_root_url in `lib.rs`
+version = "0.3.0" # Remember to sync html_root_url in `lib.rs`
 authors = ["ISSOtm <me@eldred.fr>", "Rangi42"]
 edition = "2018"
 description = "A library for working with RGBDS object files."

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@
 //!
 //! [RGBDS]: https://rgbds.gbdev.io
 
-#![doc(html_root_url = "https://docs.rs/rgbds-obj/0.2.1")]
+#![doc(html_root_url = "https://docs.rs/rgbds-obj/0.3.0")]
 
 use std::convert::TryInto;
 use std::error::Error;


### PR DESCRIPTION
Supports RGBDS 0.9.0. Release that first and update this accordingly.