### PR TITLE
Support RPN operand $62 `BIT_INDEX` for link-time `bit/res/set`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@
 //!
 //! RGBDS release                                          | Object file format
 //! -------------------------------------------------------|-------------------
+//! [v0.9.2](https://rgbds.gbdev.io/docs/v0.9.2/rgbds.5)   | v9 r12
 //! [v0.9.1](https://rgbds.gbdev.io/docs/v0.9.1/rgbds.5)   | v9 r11
 //! [v0.9.0](https://rgbds.gbdev.io/docs/v0.9.0/rgbds.5)   | v9 r11
 //! [v0.8.0](https://rgbds.gbdev.io/docs/v0.8.0/rgbds.5)   | v9 r10
@@ -98,11 +99,11 @@ impl Object {
         }
 
         let revision = read_u32le(&mut input)?;
-        if !(6..=11).contains(&revision) {
+        if !(6..=12).contains(&revision) {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 format!(
-                    "Object file {} revision {revision} is not supported (must be between 6 and 11)",
+                    "Object file {} revision {revision} is not supported (must be between 6 and 12)",
                     version as char
                 ),
             ));


### PR DESCRIPTION
Implemented for RGBDS 0.9.2 in https://github.com/gbdev/rgbds/pull/1654

This assembly:

```asm
section "test", rom0
bit VALUE, a
res VALUE * 2 + 3, b
set VALUE * VALUE, [hl]
```

Gives this output for `rgbobj -p rpn`:

```
SECTION "test"
    RPN expression:
        Sym#0 Sym#0 * SET<[HL]>
    RPN expression:
        Sym#0 $0002 * $0003 + RES<B>
    RPN expression:
        Sym#0 BIT<A>
```

And this output for `rgbobj -p rpn -r infix`:

```
SECTION "test"
    infix expression:
        SET<[HL]> (Sym#0 * Sym#0)
    infix expression:
        RES<B> (Sym#0 * $0002 + $0003)
    infix expression:
        BIT<A> Sym#0
```