### PR TITLE
Release 0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rgbds-obj"
-version = "0.3.0" # Remember to sync html_root_url in `lib.rs`
+version = "0.4.0" # Remember to sync html_root_url in `lib.rs`
 authors = ["ISSOtm <me@eldred.fr>", "Rangi42"]
 edition = "2018"
 description = "A library for working with RGBDS object files."

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@
 //!
 //! [RGBDS]: https://rgbds.gbdev.io
 
-#![doc(html_root_url = "https://docs.rs/rgbds-obj/0.3.0")]
+#![doc(html_root_url = "https://docs.rs/rgbds-obj/0.4.0")]
 
 use std::convert::TryInto;
 use std::error::Error;


### PR DESCRIPTION
After RGBDS 0.9.2 is released, we'll need to merge this and release rgbds-obj 0.4.0 on crates.io.