### PR TITLE
Move `is_rept` from rgbobj

### DIFF
--- a/src/fstack.rs
+++ b/src/fstack.rs
@@ -51,6 +51,11 @@ impl Node {
     pub fn is_quiet(&self) -> &bool {
         &self.quiet
     }
+
+    /// Whether the node is a `REPT`.
+    pub fn is_rept(&self) -> bool {
+        matches!(self.type_data(), NodeType::Rept(..))
+    }
 }
 
 /// A file stack node's type, and associated type-dependent data.


### PR DESCRIPTION
Goes with https://github.com/gbdev/rgbobj/pull/19